### PR TITLE
getAnchorDelta fix position.altitude value assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -503,7 +503,7 @@ module.exports = function(app) {
       }
       else
       {
-        var depth = configuration.position.altitude
+        var depth = position.altitude
             //_.get(app.signalk.self,
 	//	          'navigation.anchor.position.altitude')
         if ( typeof depth != 'undefined' )


### PR DESCRIPTION
Fix for this exception after `/setAnchorPosition` is called:

```
POST /plugins/anchoralarm/setAnchorPosition 500 61.830 ms - 1214
TypeError: Cannot read property 'altitude' of undefined
    at getAnchorDelta (/home/signalk/.signalk/node_modules/signalk-anchoralarm-p
lugin/index.js:506:44)
    at router.post (/home/signalk/.signalk/node_modules/signalk-anchoralarm-plug
in/index.js:287:19)
    at Layer.handle [as handle_request] (/home/signalk/node_modules/express/lib/
router/layer.js:95:5)
    at next (/home/signalk/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/home/signalk/node_modules/express/lib/router/route.js:11
2:3)
    at Layer.handle [as handle_request] (/home/signalk/node_modules/express/lib/
router/layer.js:95:5)
    at /home/signalk/node_modules/express/lib/router/index.js:281:22
    at Function.process_params (/home/signalk/node_modules/express/lib/router/in
dex.js:335:12)
    at next (/home/signalk/node_modules/express/lib/router/index.js:275:10)
    at Function.handle (/home/signalk/node_modules/express/lib/router/index.js:1
74:3)
```