### PR TITLE
fix: When setting maxRadius the value of currentRadius is not touched anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ module.exports = function(app) {
 
         app.debug("set anchor radius: " + radius)
 
-        var delta = getAnchorDelta(app, configuration.position, radius,
+        var delta = getAnchorDelta(app, configuration.position, null,
                                    radius, false, null);
         app.handleMessage(plugin.id, delta)
         


### PR DESCRIPTION
When setting maxRadius the value of currentRadius is not touched anymore. Before when executing 'setRadius' to set the alarm radius, a single delta with value maxRadius was emitted for the path currentRadius.