### PR TITLE
usability fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -417,6 +417,24 @@ module.exports = function(app) {
       }
     })
 
+		router.post("/bowHeight", (req, res) => {
+			configuration =  {
+				bowHeight: req.body.bowHeight
+			}
+
+      try {
+        savePluginOptions()
+        res.send('ok')
+      } catch ( err ) {
+        app.error(err)
+        res.status(500)
+        res.send("can't save config")
+      }
+		});
+
+		router.get("/configuration", (req, res) => {
+			res.send(configuration);
+		});
     router.post("/raiseAnchor", (req, res) => {
       try {
         raiseAnchor()

--- a/public/index.html
+++ b/public/index.html
@@ -171,6 +171,7 @@
   }, 1500);
 
   $.get('/signalk/v1/api/vessels/self', (data) => {
+		try {
       mmsi = data.mmsi;
       data = data.navigation;
       latitude = data.position.value.latitude;
@@ -181,6 +182,9 @@
       } else {
         heading = 0;
       }
+			if (!latitude | !longitude) {
+				alert("GPS does not have a fix on your position!");
+			}
       let latlng = L.latLng(latitude, longitude);
       zoom = 17;
       if (urlParams.has('zoom')) {
@@ -199,6 +203,12 @@
       } else {
 	$('#anchorUp').show();
       }
+		} catch (error) {
+			console.error("ERROR: ", error);
+				if (!boat) {
+					alert("Error retrieving vessel configuration. Have you configured your vessel in the SignalK server settings?");
+				}
+		}
   });
 
   satelliteLayer = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
@@ -237,28 +247,37 @@
     }
   });
 
-  $('#dropAnchor').click( () => {
-    $.post('/plugins/anchoralarm/dropAnchor', () => {
-      $.get('/signalk/v1/api/vessels/self/environment/depth/belowTransducer/value', (depth) => {
-        let radius = Math.round(parseInt(depth)*5);
-        $.post('/plugins/anchoralarm/setRadius', { radius: radius }, () => {
-          $.get('/signalk/v1/api/vessels/self/navigation', (data) => {
-	    dropAnchor(data.position.value, radius);
-	  });
-        });
-      }).fail(() => {
-        let newRadius = prompt('Couldn\'t determine depth, Enter Radius (m)', 50);
-        if (newRadius) {
-          $.post('/plugins/anchoralarm/setRadius', { radius: newRadius }, () => {
-	    dropAnchor(data.position, newRadius);
-          });
-        }
-      });
-    }).fail((response) => {
-	if (response.status = 401) {
-	  location.href="/admin/#/login";
-	}
-    });
+  $('#dropAnchor').click(async () => {
+		let res = await $.get("/plugins/anchoralarm/configuration");
+		console.log(res);
+		if(!res) {
+			let bowHeight = prompt('Config is missing values. Enter bowHeight', 0);
+			await $.post('/plugins/anchoralarm/bowHeight', {
+				bowHeight
+			});
+		} else {
+			$.post('/plugins/anchoralarm/dropAnchor', () => {
+				$.get('/signalk/v1/api/vessels/self/environment/depth/belowTransducer/value', (depth) => {
+					let radius = Math.round(parseInt(depth)*5);
+					$.post('/plugins/anchoralarm/setRadius', { radius: radius }, () => {
+						$.get('/signalk/v1/api/vessels/self/navigation', (data) => {
+							dropAnchor(data.position.value, radius);
+						});
+					});
+				}).fail(() => {
+					let newRadius = prompt('Couldn\'t determine depth, Enter Radius (m)', 50);
+					if (newRadius) {
+						$.post('/plugins/anchoralarm/setRadius', { radius: newRadius }, () => {
+							dropAnchor(data.position, newRadius);
+						});
+					}
+				});
+			}).fail((response) => {
+				if (response.status === 401) {
+					location.href="/admin/#/login";
+				}
+			});
+		}
   });
 
   $('#setRadius').click( () => {


### PR DESCRIPTION
- Don't redirect on an error to `dropAnchor` (it wasn't performing an equality check correctly).
- Prompt user to set configuration (bowHeight) if they haven't before dropping anchor
- Throw a better error message if GPS doesn't have a fix on user's position
- Alert user that they have not configured their vessel in the SignalK server settings