### PR TITLE
Send alarm when anchorState changes between warn/alarm

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const subscribrPeriod = 1000
 module.exports = function (app) {
   var plugin = {}
   var alarm_sent = false
+  var prev_anchorState = false
   let onStop = []
   var positionInterval
   var configuration
@@ -339,9 +340,10 @@ module.exports = function (app) {
             app.handleMessage(plugin.id, anchorDelta)
             delayStartTime = undefined
             alarm_sent = null
-          } else if (!was_sent) {
+          } else if (!was_sent || prev_anchorState != anchorState) {
             sendAnchorAlarm(anchorState, app, plugin)
           }
+          prev_anchorState = anchorState
         }
 
         if (typeof trueHeading !== 'undefined' || position) {


### PR DESCRIPTION
If an alarm had been sent for entering warning state a subsequent alarm would not be sent if vessel then moved outside of alarm radius.

See issue: https://github.com/sbender9/signalk-anchoralarm-plugin/issues/51