### PR TITLE
Add custom map source feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -781,6 +781,10 @@ module.exports = function (app) {
     router.get('/getTrack', (req, res) => {
       res.json(track)
     })
+
+    router.get('/getCustomMap', (req, res) => {
+      res.json({ url: configuration.customMapDataURL, maxNativeZoom: configuration.customMapMaxNativeZoom })
+    })
   }
 
   function calculateRodeLength(vesselPosition) {
@@ -989,6 +993,20 @@ module.exports = function (app) {
         description:
           'An alarm will be sent after this many minutes if the anchoring process has not been completed (0 to disable)',
         default: 10
+      },
+      customMapDataURL: {
+        type: 'string',
+        title: 'Custom Map Data URL',
+        description:
+          'eg. http://localhost:3000/signalk/chart-tiles/skMBTiles/{z}/{x}/{y}.png',
+        default: ''
+      },
+      customMapMaxNativeZoom: {
+        type: 'number',
+        title: 'Custom Map Max Zoom Level',
+        description:
+          'Maximum zoom level of custom chart data (optional, supports overzoom)',
+        default: 19
       }
     }
   }

--- a/public/index.html
+++ b/public/index.html
@@ -353,9 +353,26 @@
     "OpenSeaMaps": openSeaMapLayer,
   };	
 
-  var layerControl = L.control.layers(baseMaps, overlayMaps, {
-    position: 'bottomright'
-  }).addTo(map);
+  new Promise((resolve, reject) => {
+    $.getJSON('/plugins/anchoralarm/getCustomMap', (mapURL) => {
+      customLayer = L.tileLayer( mapURL.url, {
+        attribution: 'Custom Map',
+        maxNativeZoom: mapURL.maxNativeZoom,
+        maxZoom: 19
+      });
+      if(mapURL.url) {
+        baseMaps["Custom"] = customLayer;
+      }
+      var layerControl = L.control.layers(baseMaps, overlayMaps, {
+        position: 'bottomright'
+      }).addTo(map);
+    }).fail((error) => {
+      var layerControl = L.control.layers(baseMaps, overlayMaps, {
+        position: 'bottomright'
+      }).addTo(map);
+    });
+  });
+
   // On smaller screens for phones, layer control will be displayed in the center
   // This also supports a future app version of the plugin
   if (/iOS|iPhone|iPod|Android/.test(navigator.userAgent)) {


### PR DESCRIPTION
Map source defined under plugin config.  Added maxZoom setting as well to support over zoom with charts/tiles that don't have 'anchor scale' zoom level.

If maps source not defined option does not appear on chart.
