### PR TITLE
Improve the location debug message

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,7 +273,7 @@ module.exports = function (app) {
 
     if ( configuration.noPositionAlarmTime != 0 ) {
       positionInterval = setInterval(() => {
-        app.debug('ing last position...')
+        app.debug('checking last position...')
         if ( !lastPositionTime || Date.now() - lastPositionTime > configuration.noPositionAlarmTime * 1000 ) {
           positionAlarmSent = true
           sendAnchorAlarm(configuration.state, app, plugin, 'No position received')


### PR DESCRIPTION
I was debugging a GPS source issue and seeing both Lat and Long for Vessel and Anchor was very helpful in determining that SignalK does not handle a position value in a GPS PGN of "0x7FFFFFFF", which shows up as "-111.8481066", when it should be interpreted as "No Fix". Might be helpful to keep this change to give a little more information.