### PR TITLE
perf: gate JSON.stringify behind debug.enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -880,7 +880,9 @@ const load = function (app: PluginServerApp): Plugin {
 
       sendAnchorAlarm('normal')
 
-      app.debug('anchor delta: ' + JSON.stringify(delta))
+      if ((app.debug as unknown as { enabled: boolean }).enabled) {
+        app.debug('anchor delta: ' + JSON.stringify(delta))
+      }
 
       state.position = {
         latitude: position.latitude,
@@ -1979,7 +1981,9 @@ const load = function (app: PluginServerApp): Plugin {
         state.rodeLength
       )
 
-      app.debug('setAnchorPosition: ' + JSON.stringify(delta))
+      if ((app.debug as unknown as { enabled: boolean }).enabled) {
+        app.debug('setAnchorPosition: ' + JSON.stringify(delta))
+      }
       app.handleMessage(plugin.id, delta)
 
       state.position = {


### PR DESCRIPTION
The position-update hot path (around line 883) and `setAnchorPosition` (around line 1984) call

```ts
app.debug('… : ' + JSON.stringify(delta))
```

unconditionally. The first runs on every position update while anchor watch is active; the second on each `setAnchorPosition` call.

With debug logging off (the production default), `JSON.stringify` still runs eagerly, allocating short-lived strings that hammer the young-generation GC. The combination of serialize cost + GC pressure is one of the bigger perf taxes a SignalK plugin pays — the same class of fix on `course-provider-plugin`'s dispatcher cut latency by ~70 % and dropped ~700 b/op of allocations on a single hot call site.

## Change

- `src/index.ts` — wrap both call sites with `if (app.debug.enabled)`.

No behaviour change otherwise.